### PR TITLE
Schlepil master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(VERSION_MAJOR   0   CACHE STRING "Project major version number.")
 set(VERSION_MINOR   2   CACHE STRING "Project minor version number.")
 mark_as_advanced(VERSION_MAJOR VERSION_MINOR)
 
+add_subdirectory(include)
 add_subdirectory(src)
 
 enable_testing()

--- a/cmake/CheckCompilerFlags.cmake
+++ b/cmake/CheckCompilerFlags.cmake
@@ -9,13 +9,15 @@ include(CheckCXXCompilerFlag)
 option(USE16 "Use 16bit int" OFF)
 option(USE64 "Use 64bit int" OFF)
 
+set(INTEGER_T_SIZE 32)
 if (USE16)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSEINT=16")
+    set(INTEGER_T_SIZE 16)
 elseif(USE64)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSEINT=64")
+    set(INTEGER_T_SIZE 64)
 else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSEINT=32")
 endif()
+
+message(STATUS "Setting sizeof(integer_t) to ${INTEGER_T_SIZE}")
 
 #
 # Check if "flag" is accepted by the current CXX compiler. If the flag is

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(TCHECKER_CONFIG_HH_IN "${CMAKE_CURRENT_SOURCE_DIR}/tchecker/config.hh.in")
+set(TCHECKER_CONFIG_HH "${CMAKE_CURRENT_BINARY_DIR}/tchecker/config.hh")
+
+configure_file(${TCHECKER_CONFIG_HH_IN} ${TCHECKER_CONFIG_HH} @ONLY)
+
+install(DIRECTORY ../include/ DESTINATION include)
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../include/ DESTINATION include)
+

--- a/include/tchecker/basictypes.hh
+++ b/include/tchecker/basictypes.hh
@@ -11,7 +11,7 @@
 #include <cstdint>
 #include <iostream>
 #include <limits>
-
+#include <tchecker/config.hh>
 /*!
  \file basictypes.hh
  \brief Definition of basic types for models
@@ -22,15 +22,15 @@ namespace tchecker {
   /*!
    \brief Type of integers
    */
-#if (USEINT==64)
+#if (INTEGER_T_SIZE==64)
 using integer_t = int64_t;
 const integer_t int_maxval = INT64_MAX;
 const integer_t int_minval = INT64_MIN;
-#elif (USEINT==32)
+#elif (INTEGER_T_SIZE==32)
 using integer_t = int32_t;
 const integer_t int_maxval = INT32_MAX;
 const integer_t int_minval = INT32_MIN;
-#elif (USEINT==16)
+#elif (INTEGER_T_SIZE==16)
 using integer_t = int16_t;
 const integer_t int_maxval = INT16_MAX;
 const integer_t int_minval = INT16_MIN;

--- a/include/tchecker/config.hh.in
+++ b/include/tchecker/config.hh.in
@@ -1,0 +1,13 @@
+/*
+ * This file is a part of the TChecker project.
+ *
+ * See files AUTHORS and LICENSE for copyright details.
+ *
+ */
+
+#ifndef TCHECKER_CONFIG_HH
+#define TCHECKER_CONFIG_HH
+
+#cmakedefine INTEGER_T_SIZE @INTEGER_T_SIZE@
+
+#endif // TCHECKER_CONFIG_HH

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,9 +19,11 @@ tck_check_cxx_flags("-fstrict-vtable-pointers" STRICT_VTABLE_POINTERS)
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g ${ERROR_LIMIT}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG -O2 -flto ${STRICT_VTABLE_POINTERS}")
 
-set(TCHECKER_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+set(TCHECKER_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+set(TCHECKER_BINARY_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/../include")
 
 include_directories(${TCHECKER_INCLUDE_DIR})
+include_directories(${TCHECKER_BINARY_INCLUDE_DIR})
 include_directories(${Boost_INCLUDE_DIRS})
 
 add_subdirectory(algorithms)
@@ -125,8 +127,6 @@ install(TARGETS tchecker libtchecker_static
 if(LIBTCHECKER_ENABLE_SHARED)
   install(TARGETS libtchecker_shared LIBRARY DESTINATION lib)
 endif()
-
-install(DIRECTORY ../include/ DESTINATION include)
 
 # Doxygen documentation + install rule
 find_package(Doxygen)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,12 +16,13 @@ tck_check_cxx_flags("-fstrict-vtable-pointers" STRICT_VTABLE_POINTERS)
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g ${ERROR_LIMIT}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG -O2 -flto ${STRICT_VTABLE_POINTERS}")
 
-set(TCHECKER_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+get_target_property(TCHECKER_INCLUDE_DIR libtchecker_static INCLUDE_DIRECTORIES)
+
 set(TCHECKER_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 include_directories(${TCHECKER_INCLUDE_DIR})
 include_directories(${TCHECKER_TEST_DIR})
-include_directories(${Boost_INCLUDE_DIRS})
+
 
 set(TEST_SRC
 ${CMAKE_CURRENT_SOURCE_DIR}/test-db.hh

--- a/test/test-db.hh
+++ b/test/test-db.hh
@@ -17,18 +17,20 @@
 #define HASH(x)  tchecker::dbm::hash(x)
 #define CMP(x)   tchecker::dbm::comparator(x)
 #define VAL(x)   tchecker::dbm::value(x)
-
-#if (USEINT==64)
+#ifndef TCHECKER_CONFIG_HH
+#error "no TCHECKER_CONFIG_HH"
+#endif
+#if (INTEGER_T_SIZE==64)
 // This has to be kept coherent with the definition of integer
 using test_int_t = int64_t; // Modify here
 const test_int_t max_int_used = std::numeric_limits<int64_t>::max() >> 1;
 const test_int_t min_int_used = std::numeric_limits<int64_t>::min() >> 1;
-#elif (USEINT==32)
+#elif (INTEGER_T_SIZE==32)
 // This has to be kept coherent with the definition of integer
 using test_int_t = int32_t; // Modify here
 const test_int_t max_int_used = std::numeric_limits<int32_t>::max() >> 1;
 const test_int_t min_int_used = std::numeric_limits<int32_t>::min() >> 1;
-#elif (USEINT==16)
+#elif (INTEGER_T_SIZE==16)
 // This has to be kept coherent with the definition of integer
 using test_int_t = int16_t; // Modify here
 const test_int_t max_int_used = std::numeric_limits<int16_t>::max() >> 1;


### PR DESCRIPTION
Hi Philipp,

I made some changes that permits to store configuration values in `tchecker/config.hh`. This should help client codes to use libtchecker with the correct size for `integer_t`. In order to be clearer I have renamed USEINT by INTEGER_T_SIZE but fill free to keep the first one.

Regarding your pull-request, I prefer to let @fredher make the review.